### PR TITLE
feat: enable 2022.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # TomorrowNightTheme Changelog
 
 ## [Unreleased]
+## [0.0.16]
 ## [0.0.15]
 ## [0.0.14]
 ## [0.0.13]

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@
 
 pluginGroup = com.github.menwhorust.tomorrownighttheme
 pluginName = Tomorrow Night Theme
-pluginVersion = 0.0.15
+pluginVersion = 0.0.16
 pluginSinceBuild = 192.8026.42
-pluginUntilBuild = 213.*
+pluginUntilBuild = 221.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.2, 2021.1, 2021.2
+pluginVerifierIdeVersions = 2020.2.4, 2020.3.2, 2021.1, 2021.2, 2022.1
 
 platformType = IC
 platformVersion = 2020.2.4


### PR DESCRIPTION
Plugin verifier task ran successfully. Also validated locally with `Install from disk`.

Fixes https://github.com/MenWhoRust/TomorrowNightTheme/issues/25